### PR TITLE
Fixing webpack error due missing file

### DIFF
--- a/dev/js/index.js
+++ b/dev/js/index.js
@@ -7,7 +7,7 @@ import thunk from 'redux-thunk';
 import promise from 'redux-promise';
 import createLogger from 'redux-logger';
 import allReducers from './reducers';
-import App from './components/app';
+import App from './components/App';
 
 const logger = createLogger();
 const store = createStore(


### PR DESCRIPTION
Webpack is failing due a missing file in index.js (it searches for "components/app.js", while the file is "components/App.js").
Renaming import to "./components/App".
