### PR TITLE
"node-sass" version changed to "^4.7.2"

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "css-loader": "^0.23.1",
     "expect": "^1.20.1",
     "node-libs-browser": "^1.0.0",
-    "node-sass": "^3.8.0",
+    "node-sass": "^4.7.2",
     "react": "^15.1.0",
     "react-addons-test-utils": "^15.1.0",
     "react-dom": "^15.1.0",


### PR DESCRIPTION
The binary of node-sass 3.8 (Windows) does not seem to be available so the install fails.