### PR TITLE
Changed package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "main": "index.js",
   "scripts": {
     "dev": "webpack",
-    "start": "webpack-dev-server"
+    "start": "webpack-dev-server",
+    "build": "webpack --config webpack.config.js"
   },
   "license": "ISC",
   "dependencies": {


### PR DESCRIPTION
Added build attribute to scripts object in package.json. webpack command was not working so I added the build attribute. Now bundle.min.js can be formed by running the command npm run build.